### PR TITLE
Colo 138: Variable pagination in API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -77,7 +77,7 @@ class PaginationToggleResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
 
     def paginate_queryset(self, queryset, request, view=None):
-        if not request.query_params.get('pagination', True):
+        if request.query_params.get('no_pagination', False):
             return list(queryset)
         return super().paginate_queryset(queryset, request, view)
 
@@ -97,7 +97,7 @@ class RestrictedQueryMixin(object):
     https://stackoverflow.com/questions/27182527/how-can-i-stop-django-rest-framework-to-show-all-records-if-query-parameter-is-w/50957733#50957733
     """
     def get_queryset(self):
-        non_filter_params = set(['limit', 'offset', 'page', 'page_size', 'format', 'no_page'])
+        non_filter_params = set(['limit', 'offset', 'page', 'page_size', 'format', 'no_pagination'])
 
         qs = super(RestrictedQueryMixin, self).get_queryset().order_by('id')
 

--- a/api/views.py
+++ b/api/views.py
@@ -15,6 +15,7 @@ import rest_framework.exceptions
 from django.http import HttpResponse, HttpResponseRedirect
 from rest_framework import pagination, viewsets, generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 from django.core.urlresolvers import reverse
 
 #============================
@@ -71,14 +72,23 @@ class SmallResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = 'page_size'
 
-class PageSizeToggleResultsSetPagination(pagination.PageNumberPagination):
+class PaginationToggleResultsSetPagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
     page_size = 10
 
-    def get_page_size(self, request):
-        if 'no_page' in request.query_params:
-            return None
-        return self.page_size
+    def paginate_queryset(self, queryset, request, view=None):
+        if request.query_params.get('no_page', False):
+            return list(queryset)
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        try: 
+            return super().get_paginated_response(data)
+        except AttributeError:
+            return Response(OrderedDict([
+                ('count', len(data)),
+                ('results', data)
+            ]))
 
 class RestrictedQueryMixin(object):
     """Cause view to fail on invalid filter query parameter.
@@ -128,7 +138,7 @@ class ProjectViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
     permission_classes = (IsAuthenticated,)
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -144,7 +154,7 @@ class SampleViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Sample.objects.all()
     serializer_class = SampleSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'sample_id',
@@ -154,7 +164,7 @@ class AnalysisViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = Analysis.objects.all()
     serializer_class = AnalysisSerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_class = AnalysisFilter
 
 
@@ -171,7 +181,7 @@ class LaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpLane.objects.all()
     serializer_class = LaneSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -193,7 +203,7 @@ class SequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpSequencing.objects.all()
     serializer_class = SequencingSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -213,7 +223,7 @@ class LibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = DlpLibrary.objects.all()
     serializer_class = LibrarySerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'pool_id',
@@ -232,7 +242,7 @@ class SublibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = SublibraryInformation.objects.all()
     serializer_class = SublibraryInformationSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -268,7 +278,7 @@ class AnalysisInformationViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpAnalysisInformation.objects.all()
     permission_classes = (IsAuthenticated, )
     filter_class = AnalysisInformationFilter
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
 
     def get_serializer_class(self):
         if self.action in ['create', 'update', 'partial_update']:
@@ -286,7 +296,7 @@ class AnalysisRunViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = AnalysisRun.objects.all()
     serializer_class = AnalysisRunSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'last_updated',
@@ -304,7 +314,7 @@ class ExperimentalMetadata(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = ChipRegion.objects.all()
     serializer_class = ChipRegionSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__jira_ticket',
@@ -316,14 +326,14 @@ class JiraUserViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = JiraUser.objects.all()
     serializer_class = JiraUserSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
 
 
 class TenxLibraryViewSet(RestrictedQueryMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLibrary.objects.all()
     serializer_class = TenxLibrarySerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -339,7 +349,7 @@ class TenxSequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = TenxSequencing.objects.all()
     serializer_class = TenxSequencingSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'library',
@@ -351,7 +361,7 @@ class TenxLaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLane.objects.all()
     serializer_class = TenxLaneSerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -362,7 +372,7 @@ class TenxChipViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxChip.objects.all()
     serializer_class = TenxChipSerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         "id",
         "lab_name"
@@ -372,7 +382,7 @@ class TenxPoolViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxPool.objects.all()
     serializer_class = TenxPoolSerializer
-    pagination_class = PageSizeToggleResultsSetPagination
+    pagination_class = PaginationToggleResultsSetPagination
     filter_fields = (
         'id',
         'libraries',

--- a/api/views.py
+++ b/api/views.py
@@ -85,6 +85,7 @@ class VariableResultsSetPagination(pagination.PageNumberPagination):
         try: 
             return super().get_paginated_response(data)
         except AttributeError:
+            # Occurs when page_size is set to None. Still want response in same JSON format
             return Response(OrderedDict([
                 ('count', len(data)),
                 ('results', data)

--- a/api/views.py
+++ b/api/views.py
@@ -72,7 +72,7 @@ class SmallResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = 'page_size'
 
-class PaginationToggleResultsSetPagination(pagination.PageNumberPagination):
+class VariableResultsSetPagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
     page_size = 10
 
@@ -138,7 +138,7 @@ class ProjectViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
     permission_classes = (IsAuthenticated,)
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -154,7 +154,7 @@ class SampleViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Sample.objects.all()
     serializer_class = SampleSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'sample_id',
@@ -164,7 +164,7 @@ class AnalysisViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = Analysis.objects.all()
     serializer_class = AnalysisSerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_class = AnalysisFilter
 
 
@@ -181,7 +181,7 @@ class LaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpLane.objects.all()
     serializer_class = LaneSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -203,7 +203,7 @@ class SequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpSequencing.objects.all()
     serializer_class = SequencingSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -223,7 +223,7 @@ class LibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = DlpLibrary.objects.all()
     serializer_class = LibrarySerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'pool_id',
@@ -242,7 +242,7 @@ class SublibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = SublibraryInformation.objects.all()
     serializer_class = SublibraryInformationSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -278,7 +278,7 @@ class AnalysisInformationViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpAnalysisInformation.objects.all()
     permission_classes = (IsAuthenticated, )
     filter_class = AnalysisInformationFilter
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
 
     def get_serializer_class(self):
         if self.action in ['create', 'update', 'partial_update']:
@@ -296,7 +296,7 @@ class AnalysisRunViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = AnalysisRun.objects.all()
     serializer_class = AnalysisRunSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'last_updated',
@@ -314,7 +314,7 @@ class ExperimentalMetadata(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = ChipRegion.objects.all()
     serializer_class = ChipRegionSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'library__jira_ticket',
@@ -326,14 +326,14 @@ class JiraUserViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = JiraUser.objects.all()
     serializer_class = JiraUserSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
 
 
 class TenxLibraryViewSet(RestrictedQueryMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLibrary.objects.all()
     serializer_class = TenxLibrarySerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -349,7 +349,7 @@ class TenxSequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = TenxSequencing.objects.all()
     serializer_class = TenxSequencingSerializer
     permission_classes = (IsAuthenticated, )
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'library',
@@ -361,7 +361,7 @@ class TenxLaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLane.objects.all()
     serializer_class = TenxLaneSerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -372,7 +372,7 @@ class TenxChipViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxChip.objects.all()
     serializer_class = TenxChipSerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         "id",
         "lab_name"
@@ -382,7 +382,7 @@ class TenxPoolViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxPool.objects.all()
     serializer_class = TenxPoolSerializer
-    pagination_class = PaginationToggleResultsSetPagination
+    pagination_class = VariableResultsSetPagination
     filter_fields = (
         'id',
         'libraries',

--- a/api/views.py
+++ b/api/views.py
@@ -77,7 +77,7 @@ class VariableResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
 
     def paginate_queryset(self, queryset, request, view=None):
-        if request.query_params.get('no_pagination', False):
+        if 'no_pagination' in request.query_params:
             return list(queryset)
         return super().paginate_queryset(queryset, request, view)
 

--- a/api/views.py
+++ b/api/views.py
@@ -71,6 +71,14 @@ class SmallResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = 'page_size'
 
+class PageSizeToggleResultsSetPagination(pagination.PageNumberPagination):
+    page_size_query_param = 'page_size'
+    page_size = 10
+
+    def get_page_size(self, request):
+        if 'no_page' in request.query_params:
+            return None
+        return self.page_size
 
 class RestrictedQueryMixin(object):
     """Cause view to fail on invalid filter query parameter.
@@ -79,7 +87,7 @@ class RestrictedQueryMixin(object):
     https://stackoverflow.com/questions/27182527/how-can-i-stop-django-rest-framework-to-show-all-records-if-query-parameter-is-w/50957733#50957733
     """
     def get_queryset(self):
-        non_filter_params = set(['limit', 'offset', 'page', 'page_size', 'format'])
+        non_filter_params = set(['limit', 'offset', 'page', 'page_size', 'format', 'no_page'])
 
         qs = super(RestrictedQueryMixin, self).get_queryset().order_by('id')
 
@@ -120,6 +128,7 @@ class ProjectViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
     permission_classes = (IsAuthenticated,)
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -135,6 +144,7 @@ class SampleViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = Sample.objects.all()
     serializer_class = SampleSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'sample_id',
@@ -144,6 +154,7 @@ class AnalysisViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = Analysis.objects.all()
     serializer_class = AnalysisSerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_class = AnalysisFilter
 
 
@@ -160,6 +171,7 @@ class LaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpLane.objects.all()
     serializer_class = LaneSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -181,6 +193,7 @@ class SequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpSequencing.objects.all()
     serializer_class = SequencingSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -200,6 +213,7 @@ class LibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = DlpLibrary.objects.all()
     serializer_class = LibrarySerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'pool_id',
@@ -218,6 +232,7 @@ class SublibraryViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = SublibraryInformation.objects.all()
     serializer_class = SublibraryInformationSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__pool_id',
@@ -253,6 +268,7 @@ class AnalysisInformationViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = DlpAnalysisInformation.objects.all()
     permission_classes = (IsAuthenticated, )
     filter_class = AnalysisInformationFilter
+    pagination_class = PageSizeToggleResultsSetPagination
 
     def get_serializer_class(self):
         if self.action in ['create', 'update', 'partial_update']:
@@ -270,6 +286,7 @@ class AnalysisRunViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = AnalysisRun.objects.all()
     serializer_class = AnalysisRunSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'last_updated',
@@ -287,6 +304,7 @@ class ExperimentalMetadata(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = ChipRegion.objects.all()
     serializer_class = ChipRegionSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'library__jira_ticket',
@@ -298,12 +316,14 @@ class JiraUserViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = JiraUser.objects.all()
     serializer_class = JiraUserSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
 
 
 class TenxLibraryViewSet(RestrictedQueryMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLibrary.objects.all()
     serializer_class = TenxLibrarySerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'name',
@@ -319,6 +339,7 @@ class TenxSequencingViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     queryset = TenxSequencing.objects.all()
     serializer_class = TenxSequencingSerializer
     permission_classes = (IsAuthenticated, )
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'library',
@@ -330,6 +351,7 @@ class TenxLaneViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxLane.objects.all()
     serializer_class = TenxLaneSerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'flow_cell_id',
@@ -340,6 +362,7 @@ class TenxChipViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxChip.objects.all()
     serializer_class = TenxChipSerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         "id",
         "lab_name"
@@ -349,6 +372,7 @@ class TenxPoolViewSet(RestrictedQueryMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, )
     queryset = TenxPool.objects.all()
     serializer_class = TenxPoolSerializer
+    pagination_class = PageSizeToggleResultsSetPagination
     filter_fields = (
         'id',
         'libraries',

--- a/api/views.py
+++ b/api/views.py
@@ -77,7 +77,7 @@ class PaginationToggleResultsSetPagination(pagination.PageNumberPagination):
     page_size = 10
 
     def paginate_queryset(self, queryset, request, view=None):
-        if request.query_params.get('no_page', False):
+        if not request.query_params.get('pagination', True):
             return list(queryset)
         return super().paginate_queryset(queryset, request, view)
 


### PR DESCRIPTION
> is there a way we can use the Colossus API to get all the results without iterating through all the pagination?

To return results all on single page (no pagination) add query parameter `no_pagination=true`
<h3> Example with /api/project/ </h3>

-  With page size = 10 (default): `/api/project/`

- With page size = 100: `/api/project/?page_size=100`

- With no pagination: `/api/project/?no_pagination`